### PR TITLE
Fixes strange github null error in download electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-download-electron",
   "description": "Grunt task to download electron",
-  "version": "2.1.1-eagle.1",
+  "version": "2.1.1-eagle.2",
   "main": "grunt.js",
   "dependencies": {
     "decompress-zip": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "decompress-zip": "0.0.4",
     "grunt": "0.4",
     "wrench": "1.5.4",
-    "github-releases": "0.1.1",
+    "github-releases": "0.2.1",
     "progress": "1.1.2"
   },
   "licenses": [


### PR DESCRIPTION
This is fixed in the updated github-releases:

https://github.com/atom/grunt-download-electron/issues/33

